### PR TITLE
Fix total mppt power and translation issues with variables in strings

### DIFF
--- a/winet-extractor/src/winetHandler.ts
+++ b/winet-extractor/src/winetHandler.ts
@@ -438,7 +438,7 @@ export class winetHandler {
             dirty: true,
           };
 
-          if (dataPointW.value !== undefined && dataPointW.name.startsWith('mppt')) {
+          if (dataPointW.value !== undefined && dataPointW.name.toLowerCase().startsWith('mppt')) {
             mpptTotalW += dataPointW.value as number;
           }
 

--- a/winet-extractor/src/winetHandler.ts
+++ b/winet-extractor/src/winetHandler.ts
@@ -394,10 +394,22 @@ export class winetHandler {
 
         let mpptTotalW = 0;
         for (const data of directResult.data.list) {
-          const nameV = data.name + ' Voltage';
-          const nameA = data.name + ' Current';
-          const nameW = data.name + ' Power';
+          const names = data.name.split('%');
+          var name = this.properties[names[0]];
+          if (!name) {
+            name = data.name;
+          }
 
+          var nameV = name + ' Voltage';
+          var nameA = name + ' Current';
+          var nameW = name + ' Power';
+
+          console.log('length', names.length);
+          if(names.length > 1) {
+            nameV = nameV.replace('{0}', names[1].replace('@', ''));
+            nameA = nameA.replace('{0}', names[1].replace('@', ''));
+            nameW = nameW.replace('{0}', names[1].replace('@', ''));
+          }
           const dataPointV: DeviceStatus = {
             name: nameV,
             slug: slugify(nameV, {lower: true, strict: true, replacement: '_'}),
@@ -427,7 +439,9 @@ export class winetHandler {
             dirty: true,
           };
 
-          mpptTotalW += dataPointW.value as number;
+          if (dataPointW.value !== undefined && dataPointW.name.startsWith('mppt')) {
+            mpptTotalW += dataPointW.value as number;
+          }
 
           this.updateDeviceStatus(receivedDevice, dataPointV);
           this.updateDeviceStatus(receivedDevice, dataPointA);

--- a/winet-extractor/src/winetHandler.ts
+++ b/winet-extractor/src/winetHandler.ts
@@ -404,7 +404,6 @@ export class winetHandler {
           var nameA = name + ' Current';
           var nameW = name + ' Power';
 
-          console.log('length', names.length);
           if(names.length > 1) {
             nameV = nameV.replace('{0}', names[1].replace('@', ''));
             nameA = nameA.replace('{0}', names[1].replace('@', ''));


### PR DESCRIPTION
Translation:
Since there can be more than 1 variable with a string we still have to add a looping through the strings.

mppt sum:
The loop added the mppts plus alls of the strings, in a sh15t you have 3 mppts and can connect 5 strings. This doubled the sum in mppt_total_power

Fixes issue #11 and #36
