### PR TITLE
Fix some data type issues that are generating log warnings

### DIFF
--- a/winet-extractor/src/homeassistant.ts
+++ b/winet-extractor/src/homeassistant.ts
@@ -177,7 +177,7 @@ export class MqttPublisher {
     }
     if (slug === 'total_power_factor') {
       configPayload.device_class = 'power_factor';
-      configPayload.unit_of_measurement = ' ';
+      delete configPayload.unit_of_measurement;
     }
     if (configPayload.device_class === '') {
       delete configPayload.device_class;

--- a/winet-extractor/src/types/HaTypes.ts
+++ b/winet-extractor/src/types/HaTypes.ts
@@ -26,6 +26,7 @@ export const DeviceClasses: Record<string, string | undefined> = {
 
 export const TextSensors: string[] = [
   'battery_operation_status',
+  'device_status',
   'running_status',
 ];
 


### PR DESCRIPTION
This PR fixes the following warnings and errors in my Home Assistant Core logs:
```
2025-05-14 15:20:37.071 WARNING (MainThread) [homeassistant.components.mqtt.sensor] The unit of measurement ` ` is not valid together with device class `power_factor`. this will stop working in HA Core 2025.7.0
2025-05-14 15:30:45.312 WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.solar_inverter_total_power_factor (<class 'homeassistant.components.mqtt.sensor.MqttSensor'>) is using native unit of measurement ' ' which is not a valid unit for the device class ('power_factor') it is using; expected one of ['no unit of measurement', '%']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mqtt%22
```

```
2025-05-14 15:30:55.320 ERROR (MainThread) [homeassistant.components.mqtt.models] Exception raised while updating state of sensor.solar_inverter_device_status, topic: 'homeassistant/sensor/SH10RT_XXXXXXXXXXX/device_status/state' with payload: b'{"value":"On-grid Operation","unit_of_measurement":""}'
```

WiNet Extractor 0.2.2
HA Core 2025.5.1
SH10RT-V112