### PR TITLE
Add startup retry when device is unreachable on startup (i18n properties)

### DIFF
--- a/winet-extractor/src/index.ts
+++ b/winet-extractor/src/index.ts
@@ -136,14 +136,20 @@ winet.setCallback((devices, deviceStatus) => {
   }
 });
 
-getProperties(logger, options.winet_host, lang, options.ssl)
-  .then(result => {
-    logger.info('Fetched i18n properties.');
+function startWithRetry(retryDelay = 10000) {
+  getProperties(logger, options.winet_host, lang, options.ssl)
+    .then(result => {
+      logger.info('Fetched i18n properties.');
 
-    winet.setProperties(result.properties);
-    winet.connect(result.forceSsl);
-  })
-  .catch(err => {
-    logger.error('Failed to fetch l18n properties required to start.', err);
-    logger.error('Is the Winet IP address correct?');
-  });
+      winet.setProperties(result.properties);
+      winet.connect(result.forceSsl);
+    })
+    .catch(err => {
+      logger.error('Failed to fetch i18n properties:', err.message);
+      const nextDelay = Math.min(retryDelay * 1.5, 60000);
+      logger.warn(`Device unreachable. Retrying in ${Math.round(retryDelay / 1000)}s...`);
+      setTimeout(() => startWithRetry(nextDelay), retryDelay);
+    });
+}
+
+startWithRetry();


### PR DESCRIPTION
Service will be stuck if i18n is not availabe during startup.

Pull request fixes that by retrying i18n.

After a power loss my winet-extractor is booting up faster than the actual device and gets blocked.