### PR TITLE
honor analytics opt-out by using ?? instead of ||

### DIFF
--- a/winet-extractor/src/index.ts
+++ b/winet-extractor/src/index.ts
@@ -73,7 +73,7 @@ const winet = new winetHandler(
   frequency,
   options.winet_user || '',
   options.winet_pass || '',
-  new Analytics(options.analytics || true)
+  new Analytics(options.analytics ?? true)
 );
 
 const configuredSensors: string[] = [];


### PR DESCRIPTION
Hey Nick,
I opted out of analytics in the add-on config but noticed telemetry going to PostHog.

Switched `||` to `??`, which only falls back on `null`/`undefined` so the default stays on when the option is unset, and an explicit `false` is respected.

Thank you so much for building and maintaining the add-on!